### PR TITLE
reorder checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+- Moved included/excluded checks against partition information up before querying usage
+
 ## [0.2.0] - 2020-12-30
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -137,6 +137,16 @@ func executeCheck(event *types.Event) (int, error) {
 	}
 
 	for _, p := range parts {
+		// Ignore excluded (or non-included) file system types
+		if !isValidFSType(p.Fstype) {
+			continue
+		}
+
+		// Ignore excluded (or non-included) file systems
+		if !isValidFSPath(p.Mountpoint) {
+			continue
+		}
+
 		device := p.Mountpoint
 		s, err := disk.Usage(device)
 		if err != nil {
@@ -149,16 +159,6 @@ func executeCheck(event *types.Event) (int, error) {
 
 		// Ignore empty file systems
 		if s.Total == 0 {
-			continue
-		}
-
-		// Ignore excluded (or non-included) file system types
-		if !isValidFSType(p.Fstype) {
-			continue
-		}
-
-		// Ignore excluded (or non-included) file systems
-		if !isValidFSPath(p.Mountpoint) {
 			continue
 		}
 


### PR DESCRIPTION
Move the partition struct checks for included/excluded up above other checks and before attempting to get usage.

Further changes for #3 

Signed-off-by: Todd Campbell <todd@sensu.io>