### PR TITLE
Add --include-read-only option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Added --include-read-only option to support ignoring read-only file systems
+
 ## [0.3.1] - 2020-12-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Flags:
   -w, --warning float             Warning threshold for file system usage (default 85)
   -c, --critical float            Critical threshold for file system usage (default 95)
   -p, --include-pseudo-fs         Include pseudo-filesystems (e.g. tmpfs) (default false)
+  -r, --include-read-only         Include read-only filesystems (default false)
   -f, --fail-on-error             Fail and exit on errors getting file system usage (e.g. permission denied) (default false)
   -h, --help                      help for check-disk-usage
 
@@ -63,6 +64,8 @@ specified as such (e.g. NTFS, C:)
 * The `--include-pseudo-fs` option is false by default meaning that on Linux
 systems file system with types such as tmpfs (e.g. /dev, /run, etc.) will
 be ignored. This takes precedence over any explicit includes or excludes.
+* The `--include-read-only` checks for the `ro` mount option on Linux and the
+`read-only` mount option on macOS. Support for Windows has not been implemented.
 * The `--fail-on-error` option determines what occurs if the check encounters an
 error, such as `permission denied` for a file system.  If true, the check will
 exit with as a critical failure and provide the error message.  If false (the

--- a/main.go
+++ b/main.go
@@ -231,7 +231,8 @@ func isValidFSPath(fsPath string) bool {
 
 func isReadOnly(mountOpts string) bool {
 	mOpts := strings.Split(mountOpts, ",")
-	// "ro" covers Linux and Windows, "read-only" covers macOS
+	// "ro" should cover Linux, macOS, and Windows, "read-only" is reportd by mount(8)
+	// on macOS so check for it, just in case
 	if contains(mOpts, "ro") || contains(mOpts, "read-only") {
 		return true
 	}

--- a/main.go
+++ b/main.go
@@ -231,7 +231,7 @@ func isValidFSPath(fsPath string) bool {
 
 func isReadOnly(mountOpts string) bool {
 	mOpts := strings.Split(mountOpts, ",")
-	// This covers Linux and macOS, is there something for Windows?
+	// "ro" covers Linux and Windows, "read-only" covers macOS
 	if contains(mOpts, "ro") || contains(mOpts, "read-only") {
 		return true
 	}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	human "github.com/dustin/go-humanize"
 	"github.com/sensu-community/sensu-plugin-sdk/sensu"
@@ -12,14 +13,15 @@ import (
 // Config represents the check plugin config.
 type Config struct {
 	sensu.PluginConfig
-	IncludeFSType []string
-	ExcludeFSType []string
-	IncludeFSPath []string
-	ExcludeFSPath []string
-	Warning       float64
-	Critical      float64
-	IncludePseudo bool
-	FailOnError   bool
+	IncludeFSType   []string
+	ExcludeFSType   []string
+	IncludeFSPath   []string
+	ExcludeFSPath   []string
+	Warning         float64
+	Critical        float64
+	IncludePseudo   bool
+	IncludeReadOnly bool
+	FailOnError     bool
 }
 
 var (
@@ -104,6 +106,15 @@ var (
 			Usage:     "Fail and exit on errors getting file system usage (e.g. permission denied) (default false)",
 			Value:     &plugin.FailOnError,
 		},
+		{
+			Path:      "include-read-only",
+			Env:       "",
+			Argument:  "include-read-only",
+			Shorthand: "r",
+			Default:   false,
+			Usage:     "Include read-only filesystems (default false)",
+			Value:     &plugin.IncludeReadOnly,
+		},
 	}
 )
 
@@ -144,6 +155,11 @@ func executeCheck(event *types.Event) (int, error) {
 
 		// Ignore excluded (or non-included) file systems
 		if !isValidFSPath(p.Mountpoint) {
+			continue
+		}
+
+		// Ignore read-only file systems?
+		if !plugin.IncludeReadOnly && isReadOnly(p.Opts) {
 			continue
 		}
 
@@ -211,6 +227,15 @@ func isValidFSPath(fsPath string) bool {
 
 	// either not in exclude list or neither list is specified
 	return true
+}
+
+func isReadOnly(mountOpts string) bool {
+	mOpts := strings.Split(mountOpts, ",")
+	// This covers Linux and macOS, is there something for Windows?
+	if contains(mOpts, "ro") || contains(mOpts, "read-only") {
+		return true
+	}
+	return false
 }
 
 func contains(a []string, s string) bool {


### PR DESCRIPTION
Support ignoring read-only file systems by default.  Rationale:  if a monitored system does not have write access to a file system, it cannot be used to create files (not the source of the problem) nor can it be used to clean up the file system (not a part of the solution).

Closes #7 since squashfs is a read-only file system.
